### PR TITLE
Fix #2 Error: HplcSimulator@0.0.1 postinstall: `sh ./install.sh` in Grun…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -146,7 +146,7 @@ module.exports = function(grunt) {
     uglify: {
       options: {
         mangle: false,
-        compress: true,
+        compress: {},
         beautify: false
       },
       js: {


### PR DESCRIPTION
Fixes #2 in Gruntfile.js due to the following [issue](https://github.com/gruntjs/grunt-contrib-uglify/issues/287).